### PR TITLE
Modify to specify Java and Intellij install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -4,25 +4,6 @@
 
 - Set up local environment.
 
-## Install Homebrew (Mac Users Only)
-
-[Homebrew](https://brew.sh/) is a package manager for macOS. It allows us to
-quickly install a number of programs we will need.
-
-### Action Item
-
-1. Open the "Terminal" application using "Spotlight Search".
-2. Type
-   `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
-   and press `<Enter>`.
-3. Follow the prompts on the screen during the installation (Note: this could
-   take a while.)
-4. After the installation has completed, you may be prompted to run two
-   additional commands to add Homebrew to your PATH. If so, run those two
-   commands in your terminal.
-5. Close the "Terminal" application.
-6. Reopen the "Terminal" application using "Spotlight Search".
-
 ## Install Adoptium JDK 11
 
 We’ll need the JDK for developing and running Java programs.
@@ -32,25 +13,6 @@ We’ll need the JDK for developing and running Java programs.
 1. Go to [this link](https://adoptium.net/temurin/releases/?version=11).
 2. Download the file based on your operating system and architecture.
 3. Open the file and follow the instructions to install the JDK.
-
-## Install Visual Studio Code (VS Code)
-
-Visual Studio Code (VS Code) is the tool that you'll use to edit code files. It
-is a text editor that provides some beneficial extensions for developers.
-
-### Action Item
-
-1. Open the
-   [Visual Studio Code webpage](https://code.visualstudio.com/Download).
-2. Click on the download option (based on your OS) and start the download.
-3. Install the program according to the installation method of your OS.
-4. Click "View" in the toolbar, then click "Command Palette" in the dropdown
-   menu, or use the shortcut `<Command ⌘> + <Shift> + P`.
-5. Type "shell command" in the box and click on "Shell Command: Install 'code'
-   command in PATH".
-6. Close the "Visual Studio Code" application.
-7. Open the "Terminal" application using "Spotlight Search".
-8. Type `code` and press `<Enter>`.
 
 ## Install IntelliJ Community Edition
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,25 @@
 
 - Set up local environment.
 
+## Install Homebrew (Mac Users Only)
+
+[Homebrew](https://brew.sh/) is a package manager for macOS. It allows us to
+quickly install a number of programs we will need.
+
+### Action Item
+
+1. Open the "Terminal" application using "Spotlight Search".
+2. Type
+   `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"`
+   and press `<Enter>`.
+3. Follow the prompts on the screen during the installation (Note: this could
+   take a while.)
+4. After the installation has completed, you may be prompted to run two
+   additional commands to add Homebrew to your PATH. If so, run those two
+   commands in your terminal.
+5. Close the "Terminal" application.
+6. Reopen the "Terminal" application using "Spotlight Search".
+
 ## Install Adoptium JDK 11
 
 We’ll need the JDK for developing and running Java programs.


### PR DESCRIPTION
Modify the Environment setup lesson to include the installation of Java and IntelliJ Community Edition Only. 

This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.